### PR TITLE
Hi, slight Ipad Fix for you.

### DIFF
--- a/ActionSheetPicker.m
+++ b/ActionSheetPicker.m
@@ -135,6 +135,9 @@
 	[pickerDateToolbar release];
 	
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentPopover) name:UIKeyboardDidHideNotification object:nil]; // Start Watching for keyboard resize
+        
 		//spawn popovercontroller
 		UIViewController *viewController = [[[UIViewController alloc] initWithNibName:nil bundle:nil] autorelease];
 		viewController.view = view;
@@ -151,6 +154,20 @@
 	}
 }
 
+-(void)presentPopover
+{
+    [self performSelector:@selector(delayedPresentPopover) withObject:nil afterDelay:0.0];
+    // Need to delay run loop otherwise keyboarddidhide has not reset the view size yet.
+}
+-(void)delayedPresentPopover
+{
+
+    [self.popOverController presentPopoverFromRect:self.view.frame inView:self.view.superview?:self.view  
+                          permittedArrowDirections:UIPopoverArrowDirectionUp animated:YES]; // I need it in this orientation but it could be Any
+    [self.popOverController setPopoverContentSize:CGSizeMake(480,260) animated:YES]; // Need to force the size Could be done before the present but
+                                                                                     // This looks nicer as the keyboard has just dropped too.
+    
+}
 - (void)showDataPicker {
 	//spawn pickerview
 	CGRect pickerFrame = CGRectMake(0, 40, self.viewSize.width, 216);
@@ -247,7 +264,13 @@
 
 
 - (void)dealloc {
-	//	NSLog(@"ActionSheet Dealloc");
+
+ 
+   if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidHideNotification object:nil];
+   // Remove the Observer for the keyboard if we set it up
+       
+   }
 	self.actionSheet = nil;
 	self.popOverController = nil;
 


### PR DESCRIPTION
Scenario:
You have a UITextField that you want to populate using a
ActionsheetPicker.
You have other UITextFields too.
You are picking up touch of the textfield in textFieldShouldBeginEditing,
resigining first responder (to hide the keyboard) and displaying the
ActionSheetPicker instead.

On Ipad the source uses a Popover instead but, If the keyboard is still showing the popup is 
sized wrongly, hiding most of the picker.

To fix this I added a NSNotification if the keyboarddidhide to
redisplay the picker.

The view size is smaller even when the keyboarddidhide notification is sent.
It appears that the view is not resized until the the next run loop so I have used a performSelector withDelay
before actually redisplaying the popover.

```
modified:   ActionSheetPicker.m
```

Added two functions -(void)presentPopover and -(void)delayedPresentPopover
Modified the showActionPicker function to add observer for UIKeyboardDidHide Notification in the Ipad Idiom section.
Modified dealloc to remove the observer

Kind regards, Spencer
