### PR TITLE
Issue in iOS 4.1 and below with hiding the UIActionSheet

### DIFF
--- a/Pickers/AbstractActionSheetPicker.m
+++ b/Pickers/AbstractActionSheetPicker.m
@@ -153,7 +153,11 @@
 }
 
 - (void)dismissPicker {
-    if (self.actionSheet && self.actionSheet.visible)
+#if __IPHONE_4_1 <= __IPHONE_OS_VERSION_MAX_ALLOWED
+    if (self.actionSheet)
+#else
+    if (self.actionSheet && [self.actionSheet isVisible])
+#endif
         [_actionSheet dismissWithClickedButtonIndex:0 animated:YES];
     else if (self.popOverController && self.popOverController.popoverVisible)
         [_popOverController dismissPopoverAnimated:YES];


### PR DESCRIPTION
Hey Tim,

```
Found a fix to issue #31.  For some reason in iOS 4.0 and 4.1 the are not honoring the visible property on UIActionSheet.  I have included my work around for it since I know others are being blocked by this issue as well.  I simply check for an existence of self.actionSheet and not what the visible property is set to for iOS 4.1 and lower, otherwise the check stays the same.
```

If you have any questions let me know.
- Eric
