### PR TITLE
Fix a method attribute mismatch warning.

### DIFF
--- a/Pickers/AbstractActionSheetPicker.h
+++ b/Pickers/AbstractActionSheetPicker.h
@@ -55,6 +55,6 @@
 - (void)addCustomButtonWithTitle:(NSString *)title value:(id)value;
 
     //For subclasses. This responds to a custom button being pressed.
-- (void)customButtonPressed:(id)sender;
+- (IBAction)customButtonPressed:(id)sender;
 
 @end


### PR DESCRIPTION
This shows up when compiling with `-Wmismatched-method-attributes`.
