### PR TITLE
Fixed bug in tabbed Application when rotate

### DIFF
--- a/Pickers/AbstractActionSheetPicker.m
+++ b/Pickers/AbstractActionSheetPicker.m
@@ -129,8 +129,8 @@
  @return    void
  */
 - (void) didRotate:(NSNotification *)notification{
-    [self hidePicker];
-    [self showActionSheetPicker];
+    if (self.popOverController.popoverVisible)
+        [self showActionSheetPicker];
 }
 
 - (UIView *)configuredPickerView {


### PR DESCRIPTION
crash if the popovercontroller is not visible and if you rotate you device when you are in another tab (Like in tabbed Application)
