### PR TITLE
Bug fix

### DIFF
--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -85,8 +85,14 @@
     UIPickerView *stringPicker = [[[UIPickerView alloc] initWithFrame:pickerFrame] autorelease];
     stringPicker.delegate = self;
     stringPicker.dataSource = self;
-    stringPicker.showsSelectionIndicator = YES;
     [stringPicker selectRow:self.selectedIndex inComponent:0 animated:NO];
+    if (self.data.count == 0) {
+        stringPicker.showsSelectionIndicator = NO;
+        stringPicker.userInteractionEnabled = NO;
+    } else {
+        stringPicker.showsSelectionIndicator = YES;
+        stringPicker.userInteractionEnabled = YES;
+    }
     
     //need to keep a reference to the picker so we can clear the DataSource / Delegate when dismissing
     self.pickerView = stringPicker;


### PR DESCRIPTION
The app doesn't crash on Done action when there are no items in self.
When there are no elements in self.data we can try to scroll the picker without app crashing.
